### PR TITLE
fix weird warning

### DIFF
--- a/libclingcon/src/constraints.cc
+++ b/libclingcon/src/constraints.cc
@@ -1123,12 +1123,12 @@ DistinctConstraint::DistinctConstraint(lit_t lit, Elements const &elements, bool
     }
 }
 
-std::unique_ptr<DistinctConstraint> DistinctConstraint::create(lit_t lit, Elements const &elements, bool sort) {
-    size_t size = sizeof(DistinctConstraint) + elements.size() * sizeof(DistinctElement);
-    for (auto const &element : elements) {
+std::unique_ptr<DistinctConstraint> DistinctConstraint::create(lit_t lit, Elements const &elems, bool sort) {
+    size_t size = sizeof(DistinctConstraint) + elems.size() * sizeof(DistinctElement);
+    for (auto const &element : elems) {
         size += element.first.size() * sizeof(co_var_t);
     }
-    return std::unique_ptr<DistinctConstraint>{new (operator new(size)) DistinctConstraint(lit, elements, sort)};
+    return std::unique_ptr<DistinctConstraint>{new (operator new(size)) DistinctConstraint(lit, elems, sort)};
 }
 
 UniqueConstraintState DistinctConstraint::create_state() {


### PR DESCRIPTION
```
/mnt/scratch/ostrowsk/anaconda3/envs/clingcon/bin/cmake -E __run_co_compile --tidy="clang-tidy;-header-filter=.*hh;-checks=clang-analyzer-*,readability-*,modernize-*,cppcoreguidelines-*,performance-*,bugprone-*,-modernize-use-trailing-return-type,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-readability-magic-numbers;-warnings-as-errors=clang-analyzer-*,readability-*,modernize-*,cppcoreguidelines-*,performance-*,bugprone-*,-modernize-use-trailing-return-type,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,;--extra-arg-before=--driver-mode=g++" --source=../../libclingcon/src/constraints.cc -- /mnt/scratch/ostrowsk/anaconda3/envs/clingcon/bin/x86_64-conda_cos6-linux-gnu-c++  -DCLINGCON_NO_VISIBILITY -I../../libclingcon -isystem /mnt/scratch/ostrowsk/anaconda3/envs/clingcon/include -Wall -Wextra -Wpedantic -Werror -g -fvisibility=hidden   -std=gnu++1z -MD -MT libclingcon/CMakeFiles/libclingcon_t.dir/src/constraints.cc.o -MF libclingcon/CMakeFiles/libclingcon_t.dir/src/constraints.cc.o.d -o libclingcon/CMakeFiles/libclingcon_t.dir/src/constraints.cc.o -c ../../libclingcon/src/constraints.cc
../../libclingcon/clingcon/constraints.hh:225:62: error: function 'Clingcon::DistinctConstraint::create' has a definition with different parameter names [readability-inconsistent-declaration-parameter-name,-warnings-as-errors]
    [[nodiscard]] static std::unique_ptr<DistinctConstraint> create(lit_t lit, Elements const &elems, bool sort);
                                                             ^
/mnt/scratch/ostrowsk/krbiz/gitpotassco/clingcon/build/debug/../../libclingcon/src/constraints.cc:1126:57: note: the definition seen here
std::unique_ptr<DistinctConstraint> DistinctConstraint::create(lit_t lit, Elements const &elements, bool sort) {
                                                        ^
/mnt/scratch/ostrowsk/krbiz/gitpotassco/clingcon/build/debug/../../libclingcon/clingcon/constraints.hh:225:62: note: differing parameters are named here: ('elems'), in definition: ('elements')
    [[nodiscard]] static std::unique_ptr<DistinctConstraint> create(lit_t lit, Elements const &elems, bool sort);
                                                             ^                                 ~~~~~
                                                                                               elements
10875 warnings generated.
```