### PR TITLE
Bump version of miniconda action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: setup miniconda
-      uses: conda-incubator/setup-miniconda@v2.0.1
+      uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: setup miniconda
-      uses: goanpeca/setup-miniconda@v1.1.2
+      uses: conda-incubator/setup-miniconda@v2.0.1
       with:
         auto-update-conda: true
         python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
Update to newer version due to security issues
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/