### PR TITLE
Make translation of optimize statements dependent on literal count

### DIFF
--- a/libclingcon/clingcon/base.hh
+++ b/libclingcon/clingcon/base.hh
@@ -74,7 +74,7 @@ constexpr uint32_t DEFAULT_CLAUSE_LIMIT{1000};
 constexpr bool DEFAULT_LITERALS_ONLY{false};
 constexpr uint32_t DEFAULT_WEIGHT_CONSTRAINT_LIMIT{0};
 constexpr uint32_t DEFAULT_DISTINCT_LIMIT{1000};
-constexpr int32_t DEFAULT_TRANSLATE_MINIMIZE{0};
+constexpr uint32_t DEFAULT_TRANSLATE_MINIMIZE{0};
 constexpr bool DEFAULT_CHECK_SOLUTION{true};
 constexpr bool DEFAULT_CHECK_STATE{false};
 constexpr bool DEFAULT_ADD_ORDER_CLAUSES{false};
@@ -238,7 +238,7 @@ struct Config {
     uint32_t clause_limit{DEFAULT_CLAUSE_LIMIT};
     uint32_t weight_constraint_limit{DEFAULT_WEIGHT_CONSTRAINT_LIMIT};
     uint32_t distinct_limit{DEFAULT_DISTINCT_LIMIT};
-    int32_t translate_minimize{DEFAULT_TRANSLATE_MINIMIZE};
+    uint32_t translate_minimize{DEFAULT_TRANSLATE_MINIMIZE};
     SolverConfig default_solver_config;
     bool sort_constraints{DEFAULT_SORT_CONSTRAINTS};
     bool literals_only{DEFAULT_LITERALS_ONLY};

--- a/libclingcon/clingcon/base.hh
+++ b/libclingcon/clingcon/base.hh
@@ -74,9 +74,9 @@ constexpr uint32_t DEFAULT_CLAUSE_LIMIT{1000};
 constexpr bool DEFAULT_LITERALS_ONLY{false};
 constexpr uint32_t DEFAULT_WEIGHT_CONSTRAINT_LIMIT{0};
 constexpr uint32_t DEFAULT_DISTINCT_LIMIT{1000};
+constexpr int32_t DEFAULT_TRANSLATE_MINIMIZE{0};
 constexpr bool DEFAULT_CHECK_SOLUTION{true};
 constexpr bool DEFAULT_CHECK_STATE{false};
-constexpr bool DEFAULT_TRANSLATE_MINIMIZE{false};
 constexpr bool DEFAULT_ADD_ORDER_CLAUSES{false};
 
 constexpr lit_t TRUE_LIT{1};          //!< The true literal.
@@ -238,10 +238,10 @@ struct Config {
     uint32_t clause_limit{DEFAULT_CLAUSE_LIMIT};
     uint32_t weight_constraint_limit{DEFAULT_WEIGHT_CONSTRAINT_LIMIT};
     uint32_t distinct_limit{DEFAULT_DISTINCT_LIMIT};
+    int32_t translate_minimize{DEFAULT_TRANSLATE_MINIMIZE};
     SolverConfig default_solver_config;
     bool sort_constraints{DEFAULT_SORT_CONSTRAINTS};
     bool literals_only{DEFAULT_LITERALS_ONLY};
-    bool translate_minimize{DEFAULT_TRANSLATE_MINIMIZE};
     bool add_order_clauses{DEFAULT_ADD_ORDER_CLAUSES};
     bool check_solution{DEFAULT_CHECK_SOLUTION};
     bool check_state{DEFAULT_CHECK_STATE};

--- a/libclingcon/clingcon/constraints.hh
+++ b/libclingcon/clingcon/constraints.hh
@@ -163,31 +163,10 @@ public:
         return elements_ + size_; // NOLINT
     }
 
-    //! Get the number of required literals in all domains.
-    [[nodiscard]] int64_t required_literals(Solver &solver) const {
-        int64_t min_size = 0;
-        for (auto [co, var] : *this) {
-            auto & vs = solver.var_state(var);
-            min_size += static_cast<int64_t>(vs.max_bound()) - vs.min_bound() - 1;
-        }
-        return min_size;
-    }
-
-    //! Mark constraint to be translated.
-    void mark_translation() {
-        translate_ = true;
-    }
-
-    //! Check if constraint is to be translated.
-    [[nodiscard]] bool translated() const {
-        return translate_;
-    }
-
 private:
     MinimizeConstraint(val_t adjust, CoVarVec const &elems, bool sort)
     : adjust_{adjust}
-    , size_{static_cast<uint32_t>(elems.size())}
-    , translate_(false) {
+    , size_{static_cast<uint32_t>(elems.size())} {
         std::copy(elems.begin(), elems.end(), elements_);
         if (sort) {
             std::sort(elements_, elements_ + size_, [](auto a, auto b) { return std::abs(a.first) > std::abs(b.first); } ); // NOLINT
@@ -195,11 +174,9 @@ private:
     }
 
     //! Integer adjustment of the constraint.
-    lit_t adjust_;
+    val_t adjust_;
     //! Number of elements in the constraint.
     uint32_t size_;
-    //! True if constraint was translated.
-    bool translate_;
     //! List of integer/string pairs representing coefficient and variable.
     std::pair<val_t, var_t> elements_[]; // NOLINT
 };

--- a/libclingcon/clingcon/constraints.hh
+++ b/libclingcon/clingcon/constraints.hh
@@ -163,10 +163,31 @@ public:
         return elements_ + size_; // NOLINT
     }
 
+    //! Get the number of required literals in all domains.
+    [[nodiscard]] int64_t required_literals(Solver &solver) const {
+        int64_t min_size = 0;
+        for (auto [co, var] : *this) {
+            auto & vs = solver.var_state(var);
+            min_size += static_cast<int64_t>(vs.max_bound()) - vs.min_bound() - 1;
+        }
+        return min_size;
+    }
+
+    //! Mark constraint to be translated.
+    void mark_translation() {
+        translate_ = true;
+    }
+
+    //! Check if constraint is to be translated.
+    [[nodiscard]] bool translated() const {
+        return translate_;
+    }
+
 private:
     MinimizeConstraint(val_t adjust, CoVarVec const &elems, bool sort)
     : adjust_{adjust}
-    , size_{static_cast<uint32_t>(elems.size())} {
+    , size_{static_cast<uint32_t>(elems.size())}
+    , translate_(false) {
         std::copy(elems.begin(), elems.end(), elements_);
         if (sort) {
             std::sort(elements_, elements_ + size_, [](auto a, auto b) { return std::abs(a.first) > std::abs(b.first); } ); // NOLINT
@@ -177,6 +198,8 @@ private:
     lit_t adjust_;
     //! Number of elements in the constraint.
     uint32_t size_;
+    //! True if constraint was translated.
+    bool translate_;
     //! List of integer/string pairs representing coefficient and variable.
     std::pair<val_t, var_t> elements_[]; // NOLINT
 };

--- a/libclingcon/clingcon/propagator.hh
+++ b/libclingcon/clingcon/propagator.hh
@@ -208,7 +208,6 @@ private:
     SigSet show_signature_;                       //!< signatures to show
     MinimizeConstraint *minimize_{nullptr};       //!< minimize constraint
     std::atomic<sum_t> minimize_bound_{no_bound}; //!< bound of the minimize constraint
-    bool translated_minimize_{false};             //!< whether a minimize constraint has been translated
     bool show_{false};                            //!< whether there is a show statement
 };
 

--- a/libclingcon/clingcon/solver.hh
+++ b/libclingcon/clingcon/solver.hh
@@ -767,6 +767,19 @@ public:
     //! propagator as well.
     bool translate(InitClauseCreator &cc, Statistics &stats, Config const &conf, ConstraintVec &constraints);
 
+    //! Enable translation of minimize constraint.
+    //!
+    //! Note that the translation of minimize constraints cannot be disabled once enabled.
+    //! Furthermore, translation only happens in the master solver.
+    void enable_translate_minimize() {
+        translate_minimize_ = true;
+    }
+
+    //! Return true if the minimize constraint has to be translated.
+    [[nodiscard]] bool translate_minimize() const {
+        return translate_minimize_;
+    }
+
     //! Optimize internal data structures.
     //!
     //! Should be called before solving/copying states.
@@ -907,6 +920,8 @@ private:
     //! The minimize constraint might not have been fully propagated below this
     //! level. See Solver::update_minimize.
     level_t minimize_level_{0};
+    //! Flag that indicates whether the minimize constraint is to be translated.
+    bool translate_minimize_{false};
 };
 
 } // namespace Clingcon

--- a/libclingcon/src/clingcon.cc
+++ b/libclingcon/src/clingcon.cc
@@ -393,7 +393,7 @@ extern "C" bool clingcon_configure(clingcon_theory_t *theory, char const *key, c
             config.distinct_limit = parse_num<uint32_t>(value);
         }
         else if (std::strcmp(key, "translate-opt") == 0) {
-            config.translate_minimize = parse_num<int32_t>(value);
+            config.translate_minimize = parse_num<uint32_t>(value);
         }
         else if (std::strcmp(key, "add-order-clauses") == 0) {
             config.add_order_clauses = parse_bool(value);
@@ -470,9 +470,12 @@ extern "C" bool clingcon_register_options(clingcon_theory_t *theory, clingo_opti
             parser_num<uint32_t>(config.distinct_limit), false, "<n>");
         opts.add(
             group, "translate-opt",
-            format("Translate minimize constraint if less than <n> literals needed [", config.translate_minimize, "]\n"
-                   "      < n<0 >  : always translate").c_str(),
-            parser_num<int32_t>(config.translate_minimize), false, "<n>");
+            format(
+                "Configure translation of minimize constraint [", config.translate_minimize, "]\n"
+                "      <n>: translate if required literals less equal to <n>\n"
+                "        0  : never translate\n"
+                "        max: always translate").c_str(),
+            parser_num<uint32_t>(config.translate_minimize), false, "<n>");
         opts.add_flag(
             group, "add-order-clauses",
             format("Add binary clauses for order literals after translation [", flag_str(config.add_order_clauses), "]").c_str(),
@@ -484,47 +487,47 @@ extern "C" bool clingcon_register_options(clingcon_theory_t *theory, clingo_opti
             format(
                 "Make the decision heuristic aware of order literls [", heuristic_str(config.default_solver_config.heuristic), "]\n"
                 "      <arg>: {none,max-chain}[,<i>]\n"
-                "      none     : use clasp's heuristic\n"
-                "      max-chain: assign chains of literals\n"
-                "      <i>      : Only enable for thread <i>").c_str(),
+                "        none     : use clasp's heuristic\n"
+                "        max-chain: assign chains of literals\n"
+                "      <i>  : Only enable for thread <i>").c_str(),
             parser_heuristic(*theory), true);
         opts.add(
             group, "sign-value",
             format(
                 "Configure the sign of order literals [", config.default_solver_config.sign_value, "]\n"
                 "      <arg>: {<n>|+|-}[,<i>]\n"
-                "      <n>: negative if its value is greater or equal to <n>\n"
-                "      <+>: always positive\n"
-                "      <->: always negative\n"
-                "      <i>: Only enable for thread <i>").c_str(),
+                "        <n>: negative iff its value is greater or equal to <n>\n"
+                "        +  : always positive\n"
+                "        -  : always negative\n"
+                "      <i>  : Only enable for thread <i>").c_str(),
             parser_sign_value(*theory, Target::SignValue), true);
         opts.add(
             group, "refine-reasons",
             format(
                 "Refine reasons during propagation [", flag_str(config.default_solver_config.refine_reasons), "]\n"
                 "      <arg>: {yes|no}[,<i>]\n"
-                "      <i>: Only enable for thread <i>").c_str(),
+                "      <i>  : Only enable for thread <i>").c_str(),
             parser_bool_thread(*theory, Target::RefineReasons), true);
         opts.add(
             group, "refine-introduce",
             format(
                 "Introduce order literals when generating reasons [", flag_str(config.default_solver_config.refine_introduce), "]\n"
                 "      <arg>: {yes|no}[,<i>]\n"
-                "      <i>: Only enable for thread <i>").c_str(),
+                "      <i>  : Only enable for thread <i>").c_str(),
             parser_bool_thread(*theory, Target::RefineIntroduce), true);
         opts.add(
             group, "propagate-chain",
             format(
                 "Use closest order literal as reason [", flag_str(config.default_solver_config.propagate_chain), "]\n"
                 "      <arg>: {yes|no}[,<i>]\n"
-                "      <i>: Only enable for thread <i>").c_str(),
+                "      <i>  : Only enable for thread <i>").c_str(),
             parser_bool_thread(*theory, Target::PropagateChain), true);
         opts.add(
             group, "split-all",
             format(
                 "Split all domains on total assignment [", flag_str(config.default_solver_config.split_all), "]\n"
                 "      <arg>: {yes|no}[,<i>]\n"
-                "      <i>: Only enable for thread <i>").c_str(),
+                "      <i>  : Only enable for thread <i>").c_str(),
             parser_bool_thread(*theory, Target::SplitAll), true);
 
         // hidden/debug

--- a/libclingcon/src/clingcon.cc
+++ b/libclingcon/src/clingcon.cc
@@ -393,7 +393,7 @@ extern "C" bool clingcon_configure(clingcon_theory_t *theory, char const *key, c
             config.distinct_limit = parse_num<uint32_t>(value);
         }
         else if (std::strcmp(key, "translate-opt") == 0) {
-            config.translate_minimize = parse_bool(value);
+            config.translate_minimize = parse_num<int32_t>(value);
         }
         else if (std::strcmp(key, "add-order-clauses") == 0) {
             config.add_order_clauses = parse_bool(value);
@@ -468,10 +468,11 @@ extern "C" bool clingcon_register_options(clingcon_theory_t *theory, clingo_opti
             group, "translate-distinct",
             format("Restrict translation of distinct constraints <n> pb constraints [", config.distinct_limit, "]").c_str(),
             parser_num<uint32_t>(config.distinct_limit), false, "<n>");
-        opts.add_flag(
+        opts.add(
             group, "translate-opt",
-            format("Translate minimize constraint into clasp's minimize constraint [", flag_str(config.translate_minimize), "]").c_str(),
-            config.translate_minimize);
+            format("Translate minimize constraint if less than <n> literals needed [", config.translate_minimize, "]\n"
+                   "      < n<0 >  : always translate").c_str(),
+            parser_num<int32_t>(config.translate_minimize), false, "<n>");
         opts.add_flag(
             group, "add-order-clauses",
             format("Add binary clauses for order literals after translation [", flag_str(config.add_order_clauses), "]").c_str(),

--- a/libclingcon/src/constraints.cc
+++ b/libclingcon/src/constraints.cc
@@ -751,8 +751,9 @@ public:
 
     //! Translate the minimize constraint into clasp's minimize constraint.
     [[nodiscard]] std::pair<bool, bool> translate(Config const &config, Solver &solver, InitClauseCreator &cc, ConstraintVec &added) final {
+        static_cast<void>(config);
         static_cast<void>(added);
-        if (!config.translate_minimize) {
+        if (!constraint_.translated()) {
             return {true, false};
         }
 

--- a/libclingcon/src/propagator.cc
+++ b/libclingcon/src/propagator.cc
@@ -475,17 +475,6 @@ bool Propagator::translate_(InitClauseCreator &cc, UniqueMinimizeConstraint mini
     // Note: the minimize constraint is added after simplification to avoid
     // propagating tagged clauses, which is not supported at the moment.
     if (minimize != nullptr) {
-        // Note: fail if translation was requested earlier
-        if (translated_minimize_ && config_.translate_minimize == 0) {
-            throw std::runtime_error("translation of minimize constraints is disabled but was enabled before");
-        }
-
-        if (translated_minimize_
-            || config_.translate_minimize < 0
-            || minimize->required_literals(master_()) <= config_.translate_minimize) {
-            minimize->mark_translation();
-            translated_minimize_ = true;
-        }
         add_minimize_(std::move(minimize));
     }
 
@@ -498,7 +487,7 @@ bool Propagator::translate_(InitClauseCreator &cc, UniqueMinimizeConstraint mini
     cc.set_state(InitState::Init);
 
     // mark minimize constraint as translated if necessary
-    if (minimize_ != nullptr && translated_minimize_) {
+    if (minimize_ != nullptr && master_().translate_minimize()) {
         minimize_ = nullptr;
     }
 

--- a/libclingcon/tests/solve.hh
+++ b/libclingcon/tests/solve.hh
@@ -147,13 +147,14 @@ inline S solve(std::string const &prg, val_t min_int = Clingcon::DEFAULT_MIN_INT
     SolverConfig sconfig{Heuristic::MaxChain, 0, false, true, true, true};
     constexpr uint32_t m = 1000;
     constexpr uint32_t f = m * 10;
+    constexpr uint32_t o = std::numeric_limits<uint32_t>::max();
     auto configs = std::array{
-        Config{{}, min_int, max_int, 0, 0, 0, 0, 0,  sconfig, false, false, false, true, true},  // basic
-        Config{{}, min_int, max_int, 0, 0, 0, 0, 0,  sconfig, true,  false, false, true, true},  // sort constraints
-        Config{{}, min_int, max_int, f, m, 0, m, -1, sconfig, true,  false, false, true, true},  // translate
-        Config{{}, min_int, max_int, f, m, 0, m, -1, sconfig, true,  false, true,  true, true},  // translate + order clauses
-        Config{{}, min_int, max_int, f, m, 0, m, -1, sconfig, true,  true,  false, true, true},  // translate literals only
-        Config{{}, min_int, max_int, f, 0, m, m, -1, sconfig, true,  false, false, true, true},  // translate weight constraints
+        Config{{}, min_int, max_int, 0, 0, 0, 0, 0, sconfig, false, false, false, true, true},  // basic
+        Config{{}, min_int, max_int, 0, 0, 0, 0, 0, sconfig, true,  false, false, true, true},  // sort constraints
+        Config{{}, min_int, max_int, f, m, 0, m, o, sconfig, true,  false, false, true, true},  // translate
+        Config{{}, min_int, max_int, f, m, 0, m, o, sconfig, true,  false, true,  true, true},  // translate + order clauses
+        Config{{}, min_int, max_int, f, m, 0, m, o, sconfig, true,  true,  false, true, true},  // translate literals only
+        Config{{}, min_int, max_int, f, 0, m, m, o, sconfig, true,  false, false, true, true},  // translate weight constraints
     };
 
     std::optional<S> last = std::nullopt;

--- a/libclingcon/tests/solve.hh
+++ b/libclingcon/tests/solve.hh
@@ -148,12 +148,12 @@ inline S solve(std::string const &prg, val_t min_int = Clingcon::DEFAULT_MIN_INT
     constexpr uint32_t m = 1000;
     constexpr uint32_t f = m * 10;
     auto configs = std::array{
-        Config{{}, min_int, max_int, 0, 0, 0, 0, sconfig, false, false, false, false, true, true},  // basic
-        Config{{}, min_int, max_int, 0, 0, 0, 0, sconfig, true,  false, false, false, true, true},  // sort constraints
-        Config{{}, min_int, max_int, f, m, 0, m, sconfig, true,  false, true,  false, true, true},  // translate
-        Config{{}, min_int, max_int, f, m, 0, m, sconfig, true,  false, true,  true,  true, true},  // translate + order clauses
-        Config{{}, min_int, max_int, f, m, 0, m, sconfig, true,  true,  true,  false, true, true},  // translate literals only
-        Config{{}, min_int, max_int, f, 0, m, m, sconfig, true,  false, true,  false, true, true},  // translate weight constraints
+        Config{{}, min_int, max_int, 0, 0, 0, 0, 0,  sconfig, false, false, false, true, true},  // basic
+        Config{{}, min_int, max_int, 0, 0, 0, 0, 0,  sconfig, true,  false, false, true, true},  // sort constraints
+        Config{{}, min_int, max_int, f, m, 0, m, -1, sconfig, true,  false, false, true, true},  // translate
+        Config{{}, min_int, max_int, f, m, 0, m, -1, sconfig, true,  false, true,  true, true},  // translate + order clauses
+        Config{{}, min_int, max_int, f, m, 0, m, -1, sconfig, true,  true,  false, true, true},  // translate literals only
+        Config{{}, min_int, max_int, f, 0, m, m, -1, sconfig, true,  false, false, true, true},  // translate weight constraints
     };
 
     std::optional<S> last = std::nullopt;


### PR DESCRIPTION
Refer to issue #55.

@rkaminsk
The summing up the size of the minimize constraint
```
for (auto [co, var] : *minimize) {
            auto & vs = master_().var_state(var);
            min_size += static_cast<uint64_t>(vs.max_bound() - vs.min_bound() - 1);
        }
```
is done twice, which is ugly.
Should I move this to a seperate `solver.literals_in_objective()` function ?
Any suggestions ?