### PR TITLE
Call `Theory.on_model` in pyclingcon example

### DIFF
--- a/examples/pyclingcon.py
+++ b/examples/pyclingcon.py
@@ -12,6 +12,6 @@ with ProgramBuilder(ctl) as bld:
 
 ctl.ground([('base', [])])
 thy.prepare(ctl)
-with ctl.solve(yield_=True) as hnd:
+with ctl.solve(yield_=True, on_model=thy.on_model) as hnd:
     for mdl in hnd:
         print([f'{key}={val}' for key, val in thy.assignment(mdl.thread_id)])


### PR DESCRIPTION
- make example work "more correct" e.g. in case of using a `&minimize` statement