### PR TITLE
catch.hpp: fix for aarch64 and powerpc

### DIFF
--- a/libclingcon/tests/catch.hpp
+++ b/libclingcon/tests/catch.hpp
@@ -7878,7 +7878,14 @@ namespace Catch {
 
 #ifdef CATCH_PLATFORM_MAC
 
-    #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
+    #if defined(__i386__) || defined(__x86_64__)
+        #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
+    #elif defined(__aarch64__)
+        #define CATCH_TRAP() __asm__(".inst 0xd4200000")
+    #elif defined(__POWERPC__)
+        #define CATCH_TRAP() __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n" \
+        : : : "memory","r0","r3","r4" ) /* NOLINT */
+    #endif
 
 #elif defined(CATCH_PLATFORM_IPHONE)
 


### PR DESCRIPTION
aarch64 code from: https://github.com/catchorg/Catch2/commit/a25c1a24af8bffd35727a888a307ff0280cf9387
ppc code from: https://github.com/osmcode/libosmium/blob/b293e96dbe2e3a9afe400768a990e107f8af3f02/test/catch/catch.hpp#L2128
https://gitlab.labos.polytechnique.fr/massot-team/mutationpp/-/blob/fd5188804fadbce5029d3a83c89320d201181a61/thirdparty/catch/include/internal/catch_debugger.h#L26