### PR TITLE
Update

### DIFF
--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -16,8 +16,32 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.12", "3.13"]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.12"
+            arch: x86_64
+          - os: ubuntu-latest
+            python-version: "3.13"
+            arch: x86_64
+          - os: macos-latest
+            python-version: "3.12"
+            arch: arm64
+          - os: macos-latest
+            python-version: "3.13"
+            arch: arm64
+          - os: macos-latest
+            python-version: "3.12"
+            arch: x86_64
+          - os: macos-latest
+            python-version: "3.13"
+            arch: x86_64
+          - os: windows-latest
+            python-version: "3.12"
+            arch: x86_64
+          - os: windows-latest
+            python-version: "3.13"
+            arch: x86_64
+
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -41,24 +65,54 @@ jobs:
           fi
 
       - name: Conda
+        if: ${{ runner.os != 'linux' }}
         uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.python-version }}
-          channels: conda-forge
-          channel-priority: strict
-          activate-environment: conda-build
+          channels: potassco/label/dev-20,conda-forge
+          channel-priority: flexible
+          conda-remove-defaults: true
           auto-update-conda: true
 
-      - name: Setup
-        shell: bash -l {0}
+      - name: Build (linux)
+        if: ${{ runner.os == 'linux' }}
         run: |
-          conda install conda-build
+          mkdir artifacts
+          chmod a+rwx artifacts
+          docker run --rm \
+            -v ${{ github.workspace }}:/work \
+            -v ${{ github.workspace }}/artifacts:/artifacts \
+            quay.io/condaforge/linux-anvil-cos7-x86_64 /bin/bash -c "
+              export VERSION_NUMBER=${{ env.VERSION_NUMBER }} && \
+              export BUILD_NUMBER=${{ env.BUILD_NUMBER }} && \
+              curl -L -o miniconda.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh && \
+              bash miniconda.sh -b && \
+              source ~/miniforge3/etc/profile.d/conda.sh && \
+              conda config --add channels potassco/label/dev-20 && \
+              conda create -n build conda-build && \
+              conda activate build && \
+              conda build /work/.github/conda --output-folder artifacts --python ${{ matrix.python-version }} && \
+              find artifacts -type f -name '*.conda' -exec cp {} /artifacts/ \;
+            "
+      - name: Build (macos_x86_64)
+        shell: bash -l {0}
+        if: ${{ runner.os == 'macos' && matrix.arch == 'x86_64' }}
+        run: |
+          conda create --platform osx-64 -n build conda-build
+          conda activate build
+          arch -x86_64 conda build .github/conda \
+            --output-folder ./artifacts \
+            --python "${{ matrix.python-version }}"
+          find artifacts -type f ! -name "*.conda" -delete
+          find artifacts -type d -empty -delete
 
-      - name: Build
+      - name: Build (windows/macos_arm64)
         shell: bash -l {0}
+        if: ${{ runner.os != 'linux' && (runner.os != 'macos' || matrix.arch != 'x86_64') }}
         run: |
+          conda create -n build conda-build
+          conda activate build
           conda build .github/conda \
-            -c potassco/label/dev-20 \
             --output-folder ./artifacts \
             --python "${{ matrix.python-version }}"
           find artifacts -type f ! -name "*.conda" -delete
@@ -67,7 +121,7 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: conda-packages-${{ matrix.os }}-py${{ matrix.python-version }}
+          name: conda-packages-${{ matrix.os }}-${{ matrix.arch }}-py${{ matrix.python-version }}
           path: artifacts
 
   upload:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,10 +35,10 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
-          channel-priority: strict
-          use-mamba: true
+          channel-priority: flexible
           environment-file: .github/test-environment.yml
           activate-environment: test-env
+          auto-update-conda: true
 
       - name: Configure
         run: |

--- a/app/src/main.cc
+++ b/app/src/main.cc
@@ -37,7 +37,7 @@ class App : public Clingo::App, private Clingo::SolveEventHandler {
             ProfilerStart("clingcon.solve.prof");
 #endif
             theory_.prepare(ctl);
-            std::ignore = ctl.solve(*this).get();
+            std::ignore = ctl.solve({}, std::ref<Clingo::SolveEventHandler>(*this));
 #ifdef CLINGCON_PROFILE
             ProfilerStop();
 #endif

--- a/lib/c-api/tests/solve.cc
+++ b/lib/c-api/tests/solve.cc
@@ -141,12 +141,11 @@ seq((T1,M),(T2,M),D) :- permutation(T1,T2), duration(T1,M,D).
         Clingo::Theory *theory_; //!< The DL theory.
     };
 
-    //! Solve a given DL problem returning all models.
+    //! Solve a given problem returning all models.
     auto solve(Clingo::Control &ctl) -> RV {
         using namespace Clingo;
-        Handler h{theory};
         RV result;
-        for (auto &&m : ctl.solve(h, {}, SolveFlags::yield)) {
+        for (auto &&m : ctl.start_solve({}, SolveFlags::yield, Handler{theory})) {
             result.emplace_back();
             auto &sol = result.back().first;
             auto &sol_bool = result.back().second;

--- a/lib/solver/include/clingcon/base.hh
+++ b/lib/solver/include/clingcon/base.hh
@@ -398,11 +398,11 @@ class InitClauseCreator final : public AbstractClauseCreator {
                                              Clingo::WeightConstraintType type) -> bool {
         auto ass = assignment();
         if (ass.is_true(lit)) {
-            if (type < 0) {
+            if (type == Clingo::WeightConstraintType::implication_left) {
                 return true;
             }
         } else if (ass.is_false(lit)) {
-            if (type > 0) {
+            if (type == Clingo::WeightConstraintType::implication_right) {
                 return true;
             }
         }

--- a/lib/solver/tests/assumptions.cc
+++ b/lib/solver/tests/assumptions.cc
@@ -64,7 +64,7 @@ struct AFixture {
 
     [[nodiscard]] auto step(Clingo::ProgramLiteralVector assumptions = {}) const {
         SolveEventHandler hnd{*prp};
-        if (ctl.solve(hnd, assumptions).get().interrupted()) {
+        if (ctl.solve(assumptions, std::ref(hnd)).interrupted()) {
             throw std::runtime_error("interrupted");
         }
         std::ranges::sort(hnd.models);

--- a/lib/solver/tests/csp.cc
+++ b/lib/solver/tests/csp.cc
@@ -252,7 +252,7 @@ TEST_CASE_METHOD(Fixture, "sum", "[solving]") {
         ctl.join(prg);
         ctl.ground();
         {
-            auto hnd = ctl.solve(seh, {}, Clingo::SolveFlags::yield);
+            auto hnd = ctl.start_solve({}, Clingo::SolveFlags::yield, std::ref(seh));
             for (auto &&mdl : hnd) {
                 auto syms = mdl.symbols(Clingo::ShowFlags::theory);
                 REQUIRE(syms.size() == 1);

--- a/lib/solver/tests/solve.hh
+++ b/lib/solver/tests/solve.hh
@@ -47,8 +47,8 @@ using O = std::vector<std::optional<val_t>>;
 
 class SolveEventHandler : public Clingo::SolveEventHandler {
   public:
-    SolveEventHandler(Propagator &p) : p{p} {}
-    void do_stats(Clingo::Stats step, Clingo::Stats accu) override { p.on_statistics(step, accu); }
+    SolveEventHandler(Propagator &p) : p{&p} {}
+    void do_stats(Clingo::Stats step, Clingo::Stats accu) override { p->on_statistics(step, accu); }
     auto do_model(Clingo::Model model) -> bool override {
         if (model.optimality_proven()) {
             if (!proven) {
@@ -58,7 +58,7 @@ class SolveEventHandler : public Clingo::SolveEventHandler {
         } else {
             proven = false;
         }
-        p.on_model(model);
+        p->on_model(model);
         std::ostringstream oss;
         bool sep = false;
         std::vector<Clingo::Symbol> symbols = model.symbols();
@@ -73,9 +73,9 @@ class SolveEventHandler : public Clingo::SolveEventHandler {
             }
         }
         std::vector<std::pair<Clingo::Symbol, val_t>> assignment;
-        for (auto const &[var, sym] : p.var_map()) {
-            if (p.shown(var)) {
-                assignment.emplace_back(sym, p.get_value(var, model.thread_id()));
+        for (auto const &[var, sym] : p->var_map()) {
+            if (p->shown(var)) {
+                assignment.emplace_back(sym, p->get_value(var, model.thread_id()));
             }
         }
         std::ranges::sort(assignment);
@@ -89,7 +89,7 @@ class SolveEventHandler : public Clingo::SolveEventHandler {
         models.emplace_back(oss.str());
         return true;
     }
-    Propagator &p;
+    Propagator *p;
     S models;
     bool proven = false;
 };
@@ -156,7 +156,7 @@ struct Fixture {
 
         ctl.ground();
 
-        if (ctl.solve(hnd).get().interrupted()) {
+        if (ctl.solve({}, std::ref(hnd)).interrupted()) {
             throw std::runtime_error("interrupted");
         }
         bool has_minimize = prp.has_minimize();
@@ -182,7 +182,7 @@ struct Fixture {
             config.set_refine_reasons(!config.refine_reasons());
             config.set_propagate_chain(!config.propagate_chain());
         }
-        if (ctl.solve(hnd).get().interrupted()) {
+        if (ctl.solve({}, std::ref(hnd)).interrupted()) {
             throw std::runtime_error("interrupted");
         }
         std::ranges::sort(hnd.models);
@@ -232,7 +232,7 @@ struct Fixture {
             ctl.ground({part});
 
             SolveEventHandler seh{prp};
-            if (ctl.solve(seh).get().interrupted()) {
+            if (ctl.solve({}, std::ref(seh)).interrupted()) {
                 throw std::runtime_error("interrupted");
             }
             if (sep) {
@@ -285,7 +285,7 @@ struct Fixture {
             ctl.ground({part});
 
             SolveEventHandler handler{p};
-            if (ctl.solve(handler).get().interrupted()) {
+            if (ctl.solve({}, std::ref(handler)).interrupted()) {
                 throw std::runtime_error("interrupted");
             }
             std::optional<val_t> bound;


### PR DESCRIPTION
This PR updates the codebase to use a newer version of the Clingo library API. The main changes involve modifications to how solve event handlers are managed and how solve operations are invoked. Additionally, the CI workflow has been expanded to support multiple architectures (x86_64 and arm64 for macOS).

- Updated Clingo API usage: Changed from `ctl.solve(handler).get()` to `ctl.solve({}, std::ref(handler))` and `ctl.start_solve({}, flags, handler)`
- Modified SolveEventHandler to store a pointer instead of a reference to the Propagator
- Updated WeightConstraintType comparisons from integer-based to explicit enum comparisons for better type safety
- Extended CI matrix to build conda packages for additional architectures (macOS arm64 and x86_64)
- Fix CI tests to use flexible channel priority