### PR TITLE
Output extended model with assignment via clasp's generic API

### DIFF
--- a/app/src/main.cc
+++ b/app/src/main.cc
@@ -45,53 +45,6 @@ class App : public Clingo::App, private Clingo::SolveEventHandler {
             ctl.main();
         }
     }
-    void do_print_model(Clingo::ConstModel model, Clingo::ModelPrinter const &default_printer) override {
-        static_cast<void>(default_printer);
-        try {
-            auto symbols = model.symbols(Clingo::ShowFlags::shown);
-
-            // print model
-            bool comma = false;
-            std::ranges::sort(symbols);
-            for (auto &sym : symbols) {
-                if (!sym.match("__csp", 2) && !sym.match("__csp_cost", 1)) {
-                    std::cout << (comma ? " " : "") << sym;
-                    comma = true;
-                }
-            }
-
-            // print assignment
-            std::cout << "\nAssignment:\n";
-            comma = false;
-            auto cost = std::optional<Clingo::Symbol>{};
-            for (auto &sym : symbols) {
-                if (sym.match("__csp", 2)) {
-                    auto arguments = sym.arguments();
-                    std::cout << (comma ? " " : "") << arguments[0] << "=" << arguments[1];
-                    comma = true;
-
-                } else if (sym.match("__csp_cost", 1)) {
-                    auto arguments = sym.arguments();
-                    cost = arguments[0];
-                }
-            }
-            std::cout << "\n";
-
-            // print cost
-            if (cost) {
-                if (cost->type() == Clingo::SymbolType::string) {
-                    std::cout << "Cost: " << cost->string() << "\n";
-                } else {
-                    std::cout << "Cost: " << *cost << "\n";
-                }
-            }
-
-            std::cerr.flush();
-        } catch (...) {
-            fprintf(stderr, "panic: printing model failed\n");
-            std::terminate();
-        }
-    }
 
     //! Register options of the theory and optimization related options.
     void do_register_options(Clingo::Options options) override {

--- a/lib/c-api/src/clingcon.cc
+++ b/lib/c-api/src/clingcon.cc
@@ -79,8 +79,8 @@ auto check(clingo_assignment_t const *assignment, clingo_propagate_control_t *co
     CLINGO_CATCH;
 }
 
-auto decide(clingo_assignment_t const *assignment, clingo_literal_t fallback, void *data, clingo_literal_t *result)
-    -> bool {
+auto decide(clingo_assignment_t const *assignment, clingo_literal_t fallback, void *data,
+            clingo_literal_t *result) -> bool {
     CLINGO_TRY {
         *result = static_cast<Propagator *>(data)->decide(Clingo::Assignment{assignment}, fallback);
     }
@@ -672,6 +672,9 @@ struct clingcon_theory {
             opts.add(group, "@2,max-int", ConfigMax::desc(), parser<ConfigMax>(config), false, "<i>");
             opts.add_flag(group, "@2,check-solution", desc_solution(), config.check_solution);
             opts.add_flag(group, "@2,check-state", desc_state(), config.check_state);
+
+            opts.set_default_value("out-assign", "__csp/2");
+            opts.set_default_value("out-cost", "__csp_cost/1:%0");
         }
         CLINGO_CATCH;
     }

--- a/lib/python-api/src/clingcon.cc
+++ b/lib/python-api/src/clingcon.cc
@@ -55,52 +55,6 @@ class ClingconApp(App):
             ) as hnd:
                 hnd.get()
 
-    def print_model(self, model: Model, default_printer: Callable[[], None]) -> None:
-        """
-        Print the given model in a custom format.
-        """
-        syms = sorted(model.symbols(shown=True))
-        cost = None
-
-        # print symbols
-        comma = False
-        for sym in syms:
-            if not sym.match("__csp", 2) and not sym.match("__csp_cost", 1):
-                if comma:
-                    stdout.write(" ")
-                else:
-                    comma = True
-                stdout.write(str(sym))
-
-        # print assignment
-        stdout.write("\nAssignment:\n")
-        comma = False
-        for sym in syms:
-            if sym.match("__csp", 2):
-                key, val = sym.arguments
-                if comma:
-                    stdout.write(" ")
-                else:
-                    comma = True
-                stdout.write(str(key))
-                stdout.write("=")
-                stdout.write(str(val))
-            if sym.match("__csp_cost", 1):
-                cost = sym.arguments[0]
-        stdout.write("\n")
-
-        # print costs
-        if cost is not None:
-            stdout.write("Cost: ")
-            if cost.type == SymbolType.String:
-                stdout.write(cost.string)
-            else:
-                stdout.write(str(cost))
-
-            stdout.write("\n")
-
-        stdout.flush()
-
     def register_options(self, options: AppOptions) -> None:
         """
         Register command-line options for the application.


### PR DESCRIPTION
This PR refactors the C++ application to delegate model output formatting to clasp's generic output API instead of implementing custom model printing logic. The change configures clasp to automatically handle CSP assignment and cost symbols through its built-in output mechanisms, simplifying the codebase while maintaining equivalent functionality.

- Removes the custom `do_print_model` override from the C++ App class
- Configures clasp's generic output options to format `__csp/2` (assignments) and `__csp_cost/1` (costs) symbols
- Applies minor code formatting improvements to function signatures

| File | Description |
| ---- | ----------- |
| app/src/main.cc | Removes custom `do_print_model` implementation, delegating model output to clasp's generic API |
| lib/c-api/src/clingcon.cc | Configures default values for `out-assign` and `out-cost` options to match the removed custom printer; applies formatting to `decide` function signature |