### PR TITLE
Add support for conditional elements in sum constraints

### DIFF
--- a/examples/conditional/knapsack.lp
+++ b/examples/conditional/knapsack.lp
@@ -1,0 +1,22 @@
+% Knapsack problem: select items to maximize value without exceeding capacity.
+% Conditional sums aggregate weight and value only for selected items.
+
+#const capacity = 10.
+
+item(1..5).
+weight(1,2). weight(2,3). weight(3,4). weight(4,2). weight(5,5).
+value(1,3).  value(2,4).  value(3,5).  value(4,2).  value(5,6).
+
+% choose a subset of items
+{ select(I) : item(I) }.
+
+% total weight of selected items must not exceed capacity
+&sum { W : select(I), weight(I,W) } <= capacity.
+
+% total value of selected items
+&sum { V : select(I), value(I,V) } = total.
+
+% maximize total value (minimize negated)
+&minimize { -1*total }.
+
+#show select/1.

--- a/examples/conditional/move_steps.lp
+++ b/examples/conditional/move_steps.lp
@@ -1,0 +1,33 @@
+% Extension of move.lp: counts total number of moves using a conditional sum
+% over the selected move actions, then minimizes it.
+
+#const end=20.
+#const stepsize=7.
+step(0..end).
+
+% domain knowledge
+&dom { 0..T*stepsize } = at(T) :- step(T).
+
+% initial state
+&sum { at(0) } = 0.
+
+% actions
+{ move(T) } :- step(T); T > 0.
+
+% effects
+&sum { at(T-1); stepsize } = at(T) :- move(T).
+
+% frame axiom
+&sum { at(T-1) } = at(T) :- not move(T); step(T); step(T-1).
+
+% goal: must reach beyond position 100
+:- &sum { at(end) } <= 100.
+
+% count total moves with a conditional sum: contributes 1 for each active move
+&sum { 1 : move(T), step(T), T > 0 } = num_moves.
+
+% find the plan with fewest moves
+&minimize { num_moves }.
+
+#show move/1.
+&show { num_moves }.

--- a/examples/conditional/optional_jobs.lp
+++ b/examples/conditional/optional_jobs.lp
@@ -1,0 +1,22 @@
+% Optional job scheduling: select jobs to run within a time limit.
+% Conditional sums aggregate durations and profits only for selected jobs.
+
+#const limit = 15.
+
+job(1..5).
+duration(1,3). duration(2,5). duration(3,4). duration(4,2). duration(5,6).
+profit(1,4).   profit(2,7).   profit(3,5).   profit(4,3).   profit(5,8).
+
+% choose which jobs to run
+{ run(J) : job(J) }.
+
+% total duration of selected jobs must fit within the time limit
+&sum { D : run(J), duration(J,D) } <= limit.
+
+% total profit of selected jobs
+&sum { P : run(J), profit(J,P) } = total.
+
+% maximize profit (minimize negated total)
+&minimize { -1*total }.
+
+#show run/1.

--- a/libclingcon/clingcon/parsing.hh
+++ b/libclingcon/clingcon/parsing.hh
@@ -109,6 +109,12 @@ class AbstractConstraintBuilder {
     virtual void show_variable(var_t idx) = 0;
     //! Get the integer representing a variable.
     [[nodiscard]] virtual auto add_variable(Clingo::Symbol var) -> var_t = 0;
+    //! Add a new anonymous (hidden) variable not associated with any symbol.
+    //! The default implementation uses a generated symbol; override for truly hidden variables.
+    [[nodiscard]] virtual auto add_anonymous_variable() -> var_t {
+        static int counter = 0;
+        return add_variable(Clingo::Function("__csp_aux", {Clingo::Number(counter++)}));
+    }
     //! Add a constraint.
     [[nodiscard]] virtual auto add_constraint(lit_t lit, CoVarVec const &elems, val_t rhs, bool strict) -> bool = 0;
     //! Add a non-linear sum constraint.

--- a/libclingcon/clingcon/propagator.hh
+++ b/libclingcon/clingcon/propagator.hh
@@ -69,6 +69,8 @@ class Propagator final : public Clingo::Heuristic {
 
     //! Add a variable to the program.
     auto add_variable(Clingo::Symbol sym) -> var_t;
+    //! Add a new anonymous variable not associated with any symbol.
+    [[nodiscard]] auto add_anonymous_variable() -> var_t;
 
     //! Enable show statement.
     //!

--- a/libclingcon/src/parsing.cc
+++ b/libclingcon/src/parsing.cc
@@ -552,14 +552,54 @@ void parse_constraint_elem(AbstractConstraintBuilder &builder, Clingo::TheoryTer
 }
 
 template <class TermVec, bool is_sum = true>
-void parse_constraint_elems(AbstractConstraintBuilder &builder, Clingo::TheoryElementSpan elements,
-                            Clingo::TheoryTerm const *rhs, TermVec &res) {
+[[nodiscard]] auto parse_constraint_elems(AbstractConstraintBuilder &builder, Clingo::TheoryElementSpan elements,
+                                          Clingo::TheoryTerm const *rhs, TermVec &res) -> bool {
     check_syntax(is_sum || elements.size() == 1, "Invalid Syntax: invalid difference constraint");
 
     for (auto const &element : elements) {
         auto tuple = element.tuple();
-        check_syntax(!tuple.empty() && element.condition().empty(), "Invalid Syntax: invalid sum constraint");
-        parse_constraint_elem<TermVec, is_sum>(builder, element.tuple().front(), res);
+        check_syntax(!tuple.empty(), "Invalid Syntax: invalid sum constraint");
+
+        if (element.condition().empty()) {
+            parse_constraint_elem<TermVec, is_sum>(builder, tuple.front(), res);
+        } else if constexpr (std::is_same_v<TermVec, CoVarVec> && is_sum) {
+            CoVarVec sub_elems;
+            parse_constraint_elem<CoVarVec, true>(builder, tuple.front(), sub_elems);
+            val_t const_val = simplify(sub_elems, true);
+
+            auto aux = builder.add_anonymous_variable();
+            auto cond_lit = builder.solver_literal(element.condition_id());
+
+            // cond_lit -> aux = sum(co_i * x_i) - const_val
+            CoVarVec eq_elems;
+            eq_elems.emplace_back(1, aux);
+            for (auto const &[co, var] : sub_elems) {
+                eq_elems.emplace_back(-co, var);
+            }
+            if (!builder.add_constraint(cond_lit, eq_elems, -const_val, false)) {
+                return false;
+            }
+            for (auto &[co, var] : eq_elems) {
+                co = safe_inv(co);
+            }
+            if (!builder.add_constraint(cond_lit, eq_elems, const_val, false)) {
+                return false;
+            }
+
+            // -cond_lit -> aux = 0
+            CoVarVec aux_elems = {{1, aux}};
+            if (!builder.add_constraint(-cond_lit, aux_elems, 0, false)) {
+                return false;
+            }
+            aux_elems = {{-1, aux}};
+            if (!builder.add_constraint(-cond_lit, aux_elems, 0, false)) {
+                return false;
+            }
+
+            res.emplace_back(1, aux);
+        } else {
+            throw_syntax_error("Invalid Syntax: invalid sum constraint");
+        }
     }
 
     if (rhs != nullptr) {
@@ -575,6 +615,7 @@ void parse_constraint_elems(AbstractConstraintBuilder &builder, Clingo::TheoryEl
             push_co(safe_inv(term.number()), res);
         }
     }
+    return true;
 }
 
 template <class TermVec>
@@ -708,7 +749,9 @@ template <class TermVec, bool is_sum = true>
     auto literal = builder.solver_literal(atom.literal());
 
     // combine coefficients
-    parse_constraint_elems<TermVec, is_sum>(builder, atom.elements(), &guard.second, elements);
+    if (!parse_constraint_elems<TermVec, is_sum>(builder, atom.elements(), &guard.second, elements)) {
+        return false;
+    }
     rhs = simplify(elements, true);
 
     // divide by gcd
@@ -727,12 +770,16 @@ template <class TermVec, bool is_sum = true>
 }
 
 // Parses minimize and maximize directives.
-void parse_objective(AbstractConstraintBuilder &builder, Clingo::TheoryAtom const &atom, int factor) {
+[[nodiscard]] auto parse_objective(AbstractConstraintBuilder &builder, Clingo::TheoryAtom const &atom, int factor)
+    -> bool {
     CoVarVec elems;
-    parse_constraint_elems<CoVarVec>(builder, atom.elements(), nullptr, elems);
+    if (!parse_constraint_elems<CoVarVec>(builder, atom.elements(), nullptr, elems)) {
+        return false;
+    }
     for (auto &[co, var] : elems) {
         builder.add_minimize(safe_mul(factor, co), var);
     }
+    return true;
 }
 
 void parse_show_elem(AbstractConstraintBuilder &builder, Clingo::TheoryTerm const &term) {
@@ -929,9 +976,13 @@ auto parse(AbstractConstraintBuilder &builder, Clingo::TheoryAtoms theory_atoms)
                 return false;
             }
         } else if (match(atom.term(), "minimize", 0)) {
-            parse_objective(builder, atom, 1);
+            if (!parse_objective(builder, atom, 1)) {
+                return false;
+            }
         } else if (match(atom.term(), "maximize", 0)) {
-            parse_objective(builder, atom, -1);
+            if (!parse_objective(builder, atom, -1)) {
+                return false;
+            }
         }
     }
     return true;

--- a/libclingcon/src/propagator.cc
+++ b/libclingcon/src/propagator.cc
@@ -49,6 +49,7 @@ class ConstraintBuilder final : public AbstractConstraintBuilder {
     void show_signature(char const *name, size_t arity) override { propagator_.show_signature(name, arity); }
     void show_variable(var_t var) override { propagator_.show_variable(var); }
     [[nodiscard]] auto add_variable(Clingo::Symbol sym) -> var_t override { return propagator_.add_variable(sym); }
+    [[nodiscard]] auto add_anonymous_variable() -> var_t override { return propagator_.add_anonymous_variable(); }
     [[nodiscard]] auto add_constraint(lit_t lit, CoVarVec const &elems, val_t rhs, bool strict) -> bool override {
         if (!strict && cc_.assignment().is_false(lit)) {
             return true;
@@ -352,6 +353,11 @@ void Propagator::add_statistics_(Clingo::UserStatistics &root, Statistics &stats
         thread.add_subkey("Literals introduced", StatisticsType::Value)
             .set_value(static_cast<double>(solver_stat.literals));
     }
+}
+
+auto Propagator::add_anonymous_variable() -> var_t {
+    ++stats_step_.num_variables;
+    return master_().add_variable(config_.min_int, config_.max_int);
 }
 
 auto Propagator::add_variable(Clingo::Symbol sym) -> var_t {

--- a/libclingcon/tests/csp.cc
+++ b/libclingcon/tests/csp.cc
@@ -283,6 +283,55 @@ TEST_CASE("nsum", "[solving]") {
     }
 }
 
+TEST_CASE("conditional sum", "[solving]") {
+    SECTION("basic") {
+        REQUIRE(solve("a. &sum{ x : a } = 5.") == S({"a x=5"}));
+        REQUIRE(solve("{a}. &sum{ x : a } = 5.") == S({"a x=5"}));
+        REQUIRE(solve("{a}. &dom{7..7}=x. &sum{ x : a } = 0. :- a.") == S({"x=7"}));
+        REQUIRE(solve("{a}. &dom{0..3}=x. &sum{ x : a } <= 2.") ==
+                S({"a x=0", "a x=1", "a x=2", "x=0", "x=1", "x=2", "x=3"}));
+        REQUIRE(solve("{a}. &sum{ x : a } = -3.", -5, 5) == S({"a x=-3"}));
+    }
+    SECTION("multiple elements") {
+        REQUIRE(solve("{a}. {b}. &dom{0..5}=x. &dom{0..5}=y. "
+                      "&sum{ x:a; y:b } = 5. :- not a. :- not b.") ==
+                S({"a b x=0 y=5", "a b x=1 y=4", "a b x=2 y=3",
+                   "a b x=3 y=2", "a b x=4 y=1", "a b x=5 y=0"}));
+        REQUIRE(solve("{a}. {b}. &dom{5..5}=x. &dom{0..0}=y. "
+                      "&sum{ x:a; y:b } = 5. :- not a. :- b.") ==
+                S({"a x=5 y=0"}));
+        REQUIRE(solve("{a}. {b}. &sum{ x:a; y:b } = 5. :- a. :- b.", 0, 0) == S({}));
+    }
+    SECTION("coefficients and constants") {
+        REQUIRE(solve("{a}. &sum{ 2*x : a } = 10. :- not a.") == S({"a x=5"}));
+        REQUIRE(solve("{a}. &sum{ -1*x : a } = -5. :- not a.") == S({"a x=5"}));
+        REQUIRE(solve("{a}. &sum{ 3 : a } = 3. :- not a.") == S({"a"}));
+        REQUIRE(solve("{a}. &sum{ 0 : a } = 0.") == S({"", "a"}));
+    }
+    SECTION("naf condition") {
+        REQUIRE(solve("{a}. &sum{ x : not a } = 5. :- a.") == S({"x=5"}));
+        REQUIRE(solve("{a}. &dom{0..0}=x. &sum{ x : not a } = 0. :- not a.") == S({"a x=0"}));
+    }
+    SECTION("mixed conditional and unconditional") {
+        REQUIRE(solve("{a}. &dom{2..2}=x. &sum{ x; y:a } = 5. :- not a.") ==
+                S({"a x=2 y=3"}));
+        REQUIRE(solve("{a}. &dom{2..2}=x. &dom{0..0}=y. &sum{ x; y:a } = 2. :- a.") ==
+                S({"x=2 y=0"}));
+    }
+    SECTION("conjunction of conditions") {
+        REQUIRE(solve("{a}. {b}. &sum{ x : a,b } = 5. :- not a. :- not b.") ==
+                S({"a b x=5"}));
+        REQUIRE(solve("{a}. {b}. &dom{0..0}=x. &sum{ x : a,b } = 0. :- not a. :- b.") ==
+                S({"a x=0"}));
+    }
+    SECTION("grounding") {
+        REQUIRE(solve("p(1..3). {a(N) : p(N)}. #show a/1. &sum{ N : a(N), p(N) } = 6.") ==
+                S({"a(1) a(2) a(3)"}));
+        REQUIRE(solve("p(1..3). {a(N) : p(N)}. #show a/1. &sum{ N : a(N), p(N) } = 3.") ==
+                S({"a(1) a(2)", "a(3)"}));
+    }
+}
+
 TEST_CASE("multishot", "[solving]") {
     SECTION("simple") {
         REQUIRE(solve_multi("#program a.\n"


### PR DESCRIPTION
 Hi! I did this experimenting with Claude (or Claude did this experimenting with me :)
 
 ## Summary                                                                                                                                                                                                
                                                                                                                                                                                                            
  - Theory elements with conditions (`&sum{ x : a }`) are now supported in sum constraints.                                                                                                                 
  - Each conditional element is encoded via an anonymous auxiliary variable constrained to equal the element's value when the condition holds and zero otherwise.
  - Adds 16 new tests covering basic cases, multiple elements, coefficients, NAF conditions, mixed conditional/unconditional, conjunction of conditions, and grounding.                                     
  - Adds `examples/conditional/` with three example programs (knapsack, optional job scheduling, move planning with step counting).                                                                         
